### PR TITLE
Proposal for experimental lib interface.

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1413,8 +1413,10 @@ class AGraph:
         self.from_string(data)
         return self
 
-    def layout(self, prog="neato", args=""):
+    def _layout(self, prog="neato", args=""):
         """Assign positions to nodes in graph.
+
+        .. caution:: EXPERIMENTAL
 
         Optional prog=['neato'|'dot'|'twopi'|'circo'|'fdp'|'nop']
         will use specified graphviz layout method.
@@ -1483,8 +1485,10 @@ class AGraph:
         else:
             return self.from_string(data)
 
-    def draw(self, path=None, format=None, prog=None, args=""):
+    def _draw(self, path=None, format=None, prog=None, args=""):
         """Output graph to path in specified format.
+
+        .. caution:: EXPERIMENTAL
 
         An attempt will be made to guess the output format based on the file
         extension of `path`.  If that fails, then the `format` parameter will
@@ -1603,7 +1607,7 @@ class AGraph:
         gv.gvFreeLayout(gvc, G)
         gv.gvFreeContext(gvc)
 
-    def layout_command_line(self, prog="neato", args=""):
+    def layout(self, prog="neato", args=""):
         """Assign positions to nodes in graph.
 
         This version of the layout command uses command line calls to neato
@@ -1628,7 +1632,7 @@ class AGraph:
         self.has_layout = True
         return
 
-    def draw_command_line(self, path=None, format=None, prog=None, args=""):
+    def draw(self, path=None, format=None, prog=None, args=""):
         """Output graph to path in specified format.
 
         This version of the draw command uses command line calls to dot

--- a/pygraphviz/tests/test_drawing.py
+++ b/pygraphviz/tests/test_drawing.py
@@ -3,33 +3,36 @@ import pygraphviz as pgv
 import pytest
 
 
-def test_drawing_error_old():
-    with pytest.raises(AttributeError):
-        A = pgv.AGraph(name="test graph")
-        A.add_path([1, 2, 3, 4])
-        d = A.draw_command_line()
-
-def test_name_error_old():
-    with pytest.raises(ValueError):
-        A = pgv.AGraph(name="test graph")
-        A.draw_command_line("foo", prog="foo")
-
 def test_drawing_error():
     with pytest.raises(AttributeError):
         A = pgv.AGraph(name="test graph")
         A.add_path([1, 2, 3, 4])
         d = A.draw()
 
+
 def test_name_error():
     with pytest.raises(ValueError):
         A = pgv.AGraph(name="test graph")
         A.draw("foo", prog="foo")
+ 
 
 def test_drawing_no_error_with_no_layout():
     A = pgv.AGraph(name="test graph")
     A.add_path([1, 2, 3, 4])
     d = A.draw(prog="nop")
     A.string_nop()
+
+
+def test_drawing_makes_file():
+    A = pgv.AGraph(name='test graph')
+    A.add_path([1, 2, 3, 4])
+    with TemporaryFile() as fh:
+        A.draw(fh, format="png", prog="twopi")
+        assert fh.tell() > 0
+    with TemporaryFile() as fh:
+        A.draw(path=fh, prog="circo", format="png")
+        assert fh.tell() > 0
+
 
 def test_drawing_to_create_dot_string():
     A = pgv.AGraph(name='test graph')
@@ -71,13 +74,72 @@ def test_drawing_to_create_dot_string():
     #print("dot representation:", dot_rep)
     #assert expected == dot_rep
 
-def test_drawing_makes_file():
-    A = pgv.AGraph(name='test graph')
-    A.add_path([1, 2, 3, 4])
-    with TemporaryFile() as fh:
-        A.draw(fh, format="png", prog="twopi")
-        assert fh.tell() > 0
-    with TemporaryFile() as fh:
-        A.draw(path=fh, prog="circo", format="png")
-        assert fh.tell() > 0
+@pytest.mark.xfail(reason="Tests of experimental Graphviz library interface")
+class TestExperimentalGraphvizLibInterface:
+    def test_drawing_error(self):
+        with pytest.raises(AttributeError):
+            A = pgv.AGraph(name="test graph")
+            A.add_path([1, 2, 3, 4])
+            d = A._draw()
+
+    def test_name_error(self):
+        with pytest.raises(ValueError):
+            A = pgv.AGraph(name="test graph")
+            A._draw("foo", prog="foo")
+
+    def test_drawing_no_error_with_no_layout(self):
+        A = pgv.AGraph(name="test graph")
+        A.add_path([1, 2, 3, 4])
+        d = A._draw(prog="nop")
+        A.string_nop()
+
+    def test_drawing_to_create_dot_string(self):
+        A = pgv.AGraph(name='test graph')
+        A.add_path([1, 2, 3, 4])
+        A._layout()
+        dot_rep = A.to_string()
+        assert "test graph" in dot_rep
+        assert "strict graph" in dot_rep
+        assert "pos" in dot_rep
+        assert "height" in dot_rep
+        assert "width" in dot_rep
+        assert "1 -- 2" in dot_rep
+        assert "2 -- 3" in dot_rep
+        assert "3 -- 4" in dot_rep
+
+        # unfortunately, the layout and dot outcomes vary
+        # with system and graphviz version. One example is
+        # shown here, the numbers can be very different.
+        expected = """strict graph "test graph" {
+        graph [bb="0,0,70.071,250.3"];
+        node [label="\\N"];
+        1	[height=0.5,
+            pos="27,18",
+            width=0.75];
+        2	[height=0.5,
+            pos="43.071,88.469",
+            width=0.75];
+        1 -- 2	[pos="31.139,36.148 33.557,46.75 36.596,60.077 39.002,70.627"];
+        3	[height=0.5,
+            pos="41.467,160.69",
+            width=0.75];
+        2 -- 3	[pos="42.666,106.69 42.423,117.64 42.115,131.52 41.872,142.47"];
+        4	[height=0.5,
+            pos="32.966,232.3",
+            width=0.75];
+        3 -- 4	[pos="39.322,178.76 38.043,189.53 36.424,203.17 35.14,213.98"];
+    }
+    """
+        #print("dot representation:", dot_rep)
+        #assert expected == dot_rep
+
+    def test_drawing_makes_file(self):
+        A = pgv.AGraph(name='test graph')
+        A.add_path([1, 2, 3, 4])
+        with TemporaryFile() as fh:
+            A._draw(fh, format="png", prog="twopi")
+            assert fh.tell() > 0
+        with TemporaryFile() as fh:
+            A._draw(path=fh, prog="circo", format="png")
+            assert fh.tell() > 0
 

--- a/pygraphviz/tests/test_layout.py
+++ b/pygraphviz/tests/test_layout.py
@@ -1,12 +1,14 @@
+import pytest
 import pygraphviz as pgv
 
 
-def test_layout_command_line():
+def test_layout():
     A = pgv.AGraph(name="test graph")
     A.add_path([1, 2, 3, 4])
     assert [n.attr["pos"] is None for n in A.nodes()] == [True, True, True, True]
-    A.layout_command_line()
+    A.layout()
     assert [n.attr["pos"] is not None for n in A.nodes()] == [True, True, True, True]
+
 
 def test_layout_defaults():
     A = pgv.AGraph(name="test graph")
@@ -17,11 +19,12 @@ def test_layout_defaults():
     assert [n.attr["pos"] is not None for n in A.nodes()] == [True] * 4
     #print("Pos after",[n.attr["pos"] for n in A.nodes()])
 
+
 def test_layout_prog_arg():
     A = pgv.AGraph(name="test graph")
     A.add_path([1, 2, 3, 4])
     assert [n.attr["pos"] is None for n in A.nodes()] == [True] * 4
-    A.layout(prog=b"dot")
+    A.layout(prog="dot")
     assert [n.attr["pos"] is not None for n in A.nodes()] == [True] * 4
     dot_pos = [n.attr["pos"] for n in A.nodes()]
 
@@ -45,6 +48,53 @@ def test_layout_prog_arg():
     result = [n.attr["pos"] for n in A.nodes()]
     assert result != dot_pos
 
-    A.layout(prog="nop")
-    result = [n.attr["pos"] for n in A.nodes()]
-    assert result != dot_pos
+
+@pytest.mark.xfail(reason="Tests of experimental Graphviz library interface")
+class TestExperimentalGraphvizLibInterface:
+    def test_layout(self):
+        A = pgv.AGraph(name="test graph")
+        A.add_path([1, 2, 3, 4])
+        assert [n.attr["pos"] is None for n in A.nodes()] == [True, True, True, True]
+        A._layout()
+        assert [n.attr["pos"] is not None for n in A.nodes()] == [True, True, True, True]
+
+    def test_layout_defaults(self):
+        A = pgv.AGraph(name="test graph")
+        A.add_path([1, 2, 3, 4])
+        #print("Pos before",[n.attr["pos"] for n in A.nodes()])
+        assert [n.attr["pos"] is None for n in A.nodes()] == [True] * 4
+        A._layout()
+        assert [n.attr["pos"] is not None for n in A.nodes()] == [True] * 4
+        #print("Pos after",[n.attr["pos"] for n in A.nodes()])
+
+    def test_layout_prog_arg(self):
+        A = pgv.AGraph(name="test graph")
+        A.add_path([1, 2, 3, 4])
+        assert [n.attr["pos"] is None for n in A.nodes()] == [True] * 4
+        A._layout(prog=b"dot")
+        assert [n.attr["pos"] is not None for n in A.nodes()] == [True] * 4
+        dot_pos = [n.attr["pos"] for n in A.nodes()]
+
+        A._layout(prog="dot")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result == dot_pos
+
+        A._layout(prog="twopi")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result != dot_pos
+
+        A._layout(prog="neato")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result != dot_pos
+
+        A._layout(prog="circo")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result != dot_pos
+
+        A._layout(prog="fdp")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result != dot_pos
+
+        A._layout(prog="nop")
+        result = [n.attr["pos"] for n in A.nodes()]
+        assert result != dot_pos


### PR DESCRIPTION
An idea for how pygraphviz/pygraphviz#244 could be incorporated in pygraphviz as an experimental feature without breaking backwards compatibility.

Add private draw and layout methods that mirror the API of their
public counterparts but are implemented in terms of the Graphviz
library interface.

This solution preserves backwards compatibility while also
incorporating the new interface for preliminary use/testing.

Adds xfailed versions of all tests for draw/layout so that the
experimental methods are tested, though the results will not
cause the suite to fail. 